### PR TITLE
Restored Rep Payee's Digital Signature

### DIFF
--- a/docassemble/ssareportchangesletter/data/questions/ssa_report_of_dedicated_account.yml
+++ b/docassemble/ssareportchangesletter/data/questions/ssa_report_of_dedicated_account.yml
@@ -112,6 +112,7 @@ code: |
   gather_receipts
   if not used_for_valid_purpose:
     how_spending_benefited_client
+  rep_payee.signature
   # final_report
   store_variables_snapshot(data={'zip':client.address.zip,
     'city': client.address.city,


### PR DESCRIPTION
fix #37 - added digital signature question which was previously removed to avoid a non-encrypted interview